### PR TITLE
[Title] Fix Platform Error

### DIFF
--- a/Log/LogUtils.cpp
+++ b/Log/LogUtils.cpp
@@ -1,7 +1,6 @@
 #include "LogUtils.h"
 
 #include "LogConstants.h"
-#include "LogPlatform.h"
 
 namespace Log
 {

--- a/externaldemofile/CMakeLists.txt
+++ b/externaldemofile/CMakeLists.txt
@@ -38,7 +38,7 @@ MESSAGE( STATUS "Add Executable by platform")
 ## Include Header Directories for Target Files
 IF ( WIN32 )
     MESSAGE( STATUS "Windows Platform for demofile")
-    ADD_EXECUTABLE( ${PROJECT_NAME} ${SRCS} ) # Removed WIN32
+    ADD_EXECUTABLE( ${PROJECT_NAME} WIN32 ${SRCS} )
     SET( STATIC_LIB lib )
     SET( DYNAMIC_LIB dll )
 ELSE ()
@@ -70,7 +70,7 @@ SET( DEMO_ARC_DIR ${DEMOFILE_DIR}/build/arc )
 
 SET( PROJECTLIST )
 
-SET( PROJECT LogProject )
+SET( PROJECT LogProject_Demo )
 
 LIST( APPEND PROJECTLIST PROJECT )
 


### PR DESCRIPTION
[Desc]
 - LogProject 자체를 빌드할 때에는 Win32 라이브러리가 링킹이 되어있지 않은 상태에서 WinMain과 SubConsole 등을 사용하려고 하기에 발생한 오류로 보임

 - LogUtils에서 LogProject를 보지 않도록 한다면 괜찮은지도..? [Type/Branch]
[Auther/Data]

## Type - fix / test / feature / refac / bug / study ## Branch -
## Auther
## Date
## Desc