### PR TITLE
[Title] Edit the CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
+set(PROJECT_NAME LogProject)
+
+if (TARGET ${PROJECT_NAME})
+    message(STATUS "# ${PROJECT_NAME} is already defined. Skipping build configuration.")
+    
+    return()
+endif()
+
 cmake_minimum_required(VERSION 3.20)
-project(LogProject LANGUAGES CXX)
+project(${PROJECT_NAME} LANGUAGES CXX)
 
 # ------ Create the library ------- #
 include(${CMAKE_SOURCE_DIR}/external/CMake/Library.cmake)


### PR DESCRIPTION
[Desc]
If the some project has the recursive sub modules that needs the log project. Then, the log project's target will be conflict each other. So, edit the CMake file that means if the project target is existed, will not progress the build configuration. [Type/Branch]
[Auther/Data]